### PR TITLE
Fixes issues when building in seperate directory.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ add_executable(mktiupgrade
 
 target_link_libraries(mktiupgrade ${LIBS})
 
-install(PROGRAMS bin/mktiupgrade
+install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/bin/mktiupgrade
     DESTINATION bin)
 
 set(CMAKE_BUILD_TYPE Release)
@@ -37,7 +37,7 @@ ADD_CUSTOM_TARGET(man ALL)
 ADD_CUSTOM_COMMAND(
   TARGET man
   SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/mktiupgrade.1.txt
-  COMMAND a2x --no-xmllint --doctype manpage --format manpage ${CMAKE_CURRENT_SOURCE_DIR}/mktiupgrade.1.txt 
+  COMMAND a2x --no-xmllint --doctype manpage --format manpage ${CMAKE_CURRENT_SOURCE_DIR}/mktiupgrade.1.txt -D ${CMAKE_CURRENT_BINARY_DIR}
   OUTPUTS ${CMAKE_CURRENT_BINARY_DIR}/mktiupgrade.1
 )
 


### PR DESCRIPTION
I had attempted to build this program within a separate build directory, however some of the cmake commands were written in a way that assumes the commands are run in the source directory. This PR allows for both building in the source directory, and building in a separate directory.

(Same issue as with [KnightOS/genkfs#4](https://github.com/KnightOS/genkfs/pull/4))