### PR TITLE
* Compilation: Fix uninitialized variable error and error about unsafe printing

### DIFF
--- a/main.c
+++ b/main.c
@@ -158,7 +158,7 @@ int main(int argc, char **argv) {
 				char *majorstr = argv[++i];
 				char *minorstr = strstr(majorstr, ".");
 				if (minorstr == NULL) {
-					fprintf(stderr, errstr);
+					fprintf(stderr, "%s", errstr);
 					exit(1);
 				}
 				minorstr++;
@@ -166,12 +166,12 @@ int main(int argc, char **argv) {
 				char *end = majorstr;
 				major = strtol(majorstr, &end, 10);
 				if (*end != '.') {
-					fprintf(stderr, errstr);
+					fprintf(stderr, "%s", errstr);
 					exit(1);
 				}
 				minor = strtol(minorstr, &end, 10);
 				if (*end != '\0') {
-					fprintf(stderr, errstr);
+					fprintf(stderr, "%s", errstr);
 					exit(1);
 				}
 				if (major < 0 || major >= 0x100 || minor < 0 || minor >= 0x100) {
@@ -331,7 +331,7 @@ int main(int argc, char **argv) {
 	}
 
 	uint8_t *signature = NULL;
-	size_t siglen;
+	size_t siglen = 0;
 	if (context.sigfile) {
 		FILE *sig = fopen(context.sigfile, "r");
 		if (!sig) {


### PR DESCRIPTION
The compiler gave me some errors

```
~/test/gitstuffs/mktiupgrade/main.c:355:13: error: variable 'siglen' is used uninitialized whenever
      'if' condition is false [-Werror,-Wsometimes-uninitialized]
~/test/gitstuffs/mktiupgrade/main.c:174:22: error: format string is not a string literal
      (potentially insecure) [-Werror,-Wformat-security]
```

These don't seem all that threatening to me, but I followed its advice to fix them.